### PR TITLE
LiteLLM support, load_dataset switch to datasets lib for caching support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+uv.lock 

--- a/evaluate.py
+++ b/evaluate.py
@@ -5,9 +5,9 @@ from lapet import LLMJudge
 config = {
     "judge": {
         "name": "openai",
-        "organization": os.environ["OPENAI_ORG"],
-        "project": os.environ["OPENAI_PROJECT"],
-        "api_key": os.environ["OPENAI_KEY"]
+        "organization": os.getenv("OPENAI_ORG"),
+        "project": os.getenv("OPENAI_PROJECT"),
+        "api_key": os.getenv("OPENAI_API_KEY")
     }
 }
 

--- a/generate.py
+++ b/generate.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import huggingface_hub
-from lapet import ModelHandler, Llama2ModelHandler, Llama3ModelHandler,Llama31ModelHandler, Phi4ModelHandler, GemmaModelHandler
+from lapet import ModelHandler, Llama2ModelHandler, Llama3ModelHandler,Llama31ModelHandler, Phi4ModelHandler, GemmaModelHandler, LiteLLMModelHandler
 
 config = {
     'batch_size': 5,
@@ -22,7 +22,13 @@ config = {
         'HuggingFaceH4/zephyr-7b-beta': ModelHandler,
         'google/gemma-7b': ModelHandler,
         'google/gemma-3-1b-it': GemmaModelHandler,
-        'google/gemma-3-4b-it': GemmaModelHandler
+        'google/gemma-3-4b-it': GemmaModelHandler,
+        # 'ollama_chat/llama3.1:8b': LiteLLMModelHandler,
+        # 'ollama_chat/phi3:14b': LiteLLMModelHandler,
+        # 'ollama_chat/phi4-mini:latest': LiteLLMModelHandler,
+        # 'ollama_chat/gemma3:12b': LiteLLMModelHandler,
+        # 'together_ai/meta-llama/Llama-4-Scout-17B-16E-Instruct': LiteLLMModelHandler,
+        # 'together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free': LiteLLMModelHandler,
     },
     'system_prompt': "You are a helpful AI assistant that generates answers to questions. You will be provided with transcripts of conversations between customers and service agents. Your task is to follow the instruction and output a response from each conversation in a valid JSON format. Focus on provided concise outputs that could be useful for follow-up actions and ensure that your outputs are directly relevant to the discussed topics. This prompt is meant to ensure that you understand the essence of the customer's concerns and can articulate it succinctly in a structured format that is easy for both human and machine processing. Continue with this approach for the upcoming conversations.",
     'prompts': [
@@ -35,7 +41,8 @@ config = {
     ]
 }
 
-huggingface_hub.login()
+# huggingface_hub.login()
+# retrieve token from HF_TOKEN environment variable
 handler = ModelHandler(config)
 responses = handler.process_dataset()
 responses.to_csv('eval_data.csv', index=False)

--- a/lapet/__init__.py
+++ b/lapet/__init__.py
@@ -3,3 +3,4 @@ from .phi import Phi4ModelHandler
 from .handler import ModelHandler
 from .gemma import GemmaModelHandler
 from .judge import LLMJudge
+from .litellm import LiteLLMModelHandler

--- a/lapet/litellm.py
+++ b/lapet/litellm.py
@@ -1,0 +1,24 @@
+class LiteLLMModel():
+    def __init__(self, model_id):
+        self.model_id = model_id
+
+    def completion(self, messages, max_tokens, temperature, top_p):
+        import litellm
+        response = litellm.completion(
+            model=self.model_id,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+        )
+        prompt, responses = response.choices[0].message.content, response.choices[0].message.content
+        return prompt, responses
+
+class LiteLLMModelHandler():
+    """
+    Model handler for LiteLLM models. Uses litellm.completion to generate outputs.
+    Assumes API key is set in environment variables (e.g., OPENAI_API_KEY).
+    """
+    def load_model_and_tokenizer(self, device, model_id):
+        self.model_id = model_id
+        return None, LiteLLMModel(model_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "transformers==4.52.3",
     "openai>=1.0.0",
     'importlib-metadata; python_version<"3.10"',
+    "datasets>=3.6.0",
+    "litellm>=1.72.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
#### Summary
- **Added support for LiteLLM models** via a new `LiteLLMModelHandler` and integration in the codebase. LiteLLM allows to call 100+ LLM APIs in OpenAI format - [Bedrock, Azure, OpenAI, VertexAI, Cohere, Anthropic, Sagemaker, HuggingFace, Replicate, Groq, DeepSeek, Ollama,  etc]
- **Switched dataset loading** in `ModelHandler` to use the Hugging Face `datasets` library for improved caching and efficiency.

#### Detailed Changes

- **New Features:**
  - Introduced `lapet/litellm.py` with `LiteLLMModel` and `LiteLLMModelHandler` for handling LiteLLM models using the `litellm` library.
  - Updated `pyproject.toml` to include `litellm` and `datasets` as dependencies.

- **Improvements:**
  - `ModelHandler.load_dataset` now uses `datasets.load_dataset` for CSV loading and caching, replacing direct pandas loading.
  - Environment variable access in `evaluate.py` switched from `os.environ` to `os.getenv` for safer key handling.

- **Integration:**
  - Registered `LiteLLMModelHandler` in `lapet/__init__.py` and made it available for use in `generate.py`.
  - Added (commented) example model entries for LiteLLM in the model config of `generate.py`.

- **Other:**
  - Minor updates to `.gitignore` (added `uv.lock`).
  - Adjusted imports and handler logic to support new features.

